### PR TITLE
feat: implement service worker for PWA offline support and asset caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Govigi PWA
 
-const CACHE_NAME = 'govigi-v2';
-const STATIC_CACHE = 'govigi-static-v2';
+const CACHE_NAME = 'govigi-v3';
+const STATIC_CACHE = 'govigi-static-v3';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -65,8 +65,14 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // API calls - network first
-  if (url.pathname.includes('/api/') || url.pathname.includes('/get')) {
+  // Only use Cache-First for static hashed assets and media.
+  // HTML pages, API calls, and sw.js itself must use Network-First to prevent stale UI caching.
+  const isStaticHashedAsset = (url.pathname.includes('_next/static/') || 
+                               /\.(png|jpe?g|gif|svg|ico|webp|woff2?|ttf|otf|css|js)$/i.test(url.pathname)) && 
+                              !url.pathname.includes('sw.js');
+
+  if (!isStaticHashedAsset || url.pathname.includes('/api/') || url.pathname.includes('/get')) {
+    // Pages, Documents, Manifests & APIs - Network First, falling back to cache
     event.respondWith(
       fetch(event.request)
         .then(response => {
@@ -81,7 +87,7 @@ self.addEventListener('fetch', event => {
         })
         .catch(() => {
           return caches.match(event.request).catch(() => {
-            return new Response('Offline - no cache available', {
+            return caches.match('/') || new Response('Offline', {
               status: 503,
               statusText: 'Service Unavailable',
               headers: new Headers({
@@ -92,7 +98,7 @@ self.addEventListener('fetch', event => {
         })
     );
   } else {
-    // Static assets - cache first, then network
+    // Static assets - Cache First, falling back to network
     event.respondWith(
       caches.match(event.request).then(response => {
         if (response) {
@@ -110,7 +116,6 @@ self.addEventListener('fetch', event => {
           });
           return response;
         }).catch(() => {
-          // Return offline page if available
           return caches.match('/') || new Response('Offline', {
             status: 503,
             statusText: 'Service Unavailable'


### PR DESCRIPTION
This pull request updates the service worker (`public/sw.js`) to improve caching strategies for the Govigi PWA, focusing on preventing stale UI and ensuring better offline support. The main changes include updating cache versioning, refining cache strategies for different asset types, and improving offline fallback behavior.

**Cache versioning:**
* Updated `CACHE_NAME` and `STATIC_CACHE` constants to new versions (`govigi-v3` and `govigi-static-v3`) to ensure users receive the latest cached assets after deployment.

**Caching strategy improvements:**
* Refined the fetch event logic: now only static hashed assets and media files use a Cache-First strategy, while HTML pages, API calls, and the service worker itself use Network-First to avoid serving outdated content.
* Clarified comments and code structure for cache strategies, making it easier to understand which resources are cached first and which use the network first.

**Offline handling enhancements:**
* Improved offline fallback: when a network request fails and is not cached, the service worker now tries to serve the cached home page (`'/'`) before returning a generic offline response, providing a better offline experience. [[1]](diffhunk://#diff-98fd1d4c44ad3934ee242b1f070d235cc39f11e46738f28de66c6740182c4706L84-R90) [[2]](diffhunk://#diff-98fd1d4c44ad3934ee242b1f070d235cc39f11e46738f28de66c6740182c4706L113)